### PR TITLE
javascript: fixed infinite reload loop when hash is empty

### DIFF
--- a/src/templates/content.latte
+++ b/src/templates/content.latte
@@ -131,6 +131,10 @@
 	});
 
 	$(window).on('load hashchange', function() {
+		if (!window.location.hash) {
+			return;
+		}
+
 		var target = $(window.location.hash);
 		target.parents('details').attr('open', true);
 		target.children('.collapse').collapse('show');


### PR DESCRIPTION
The `window.location.href = window.location.hash` line causes page reload when the `#` part is empty. (The line is necessary because automatic browser scroll to anchor is executed before collapsed elements are expanded so the anchor has to be triggered again.)